### PR TITLE
Added support for handling the mysocietyemergency.org certificate

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,10 @@ class Vhosts(collections.Mapping):
                 'cacti.mysociety.org', 'graphite.mysociety.org', 'puppet-dashboard.mysociety.org', 'git.mysociety.org'
             ] 
         }
+        self.vhosts['mysocietyemergency.org'] = {
+            'servers': ['emergency'],
+            'aliases': ['www.mysocietyemergency.org']
+        }
 
     def __getitem__(self, key):
         vhost = self.vhosts[key]


### PR DESCRIPTION
Although I don't like having exceptions like this in the code, it seems the simplest way to integrate the renewal of this cert into our Letsencrypt framework for the time being given it sits outside our infrastructure in other respects. I'll have a think about how we could potentially integrate certificate handling for domains outside our traditional deployment system, I think it would be useful.