### PR TITLE
Make SSL domain list and CN a bit more deterministic

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -58,12 +58,14 @@ class Vhosts(collections.Mapping):
         else:
             cn = vhost_name
         dns_names.remove(cn)
-
-        if cn in ignore:
-            cn = dns_names.pop()
         dns_names -= set(ignore)
 
-        return [cn] + sorted(list(dns_names))
+        if cn in ignore:
+            ssl_dns_names = sorted(list(dns_names))
+        else:
+            ssl_dns_names = [cn] + sorted(list(dns_names))
+
+        return ssl_dns_names
 
     def _parse_vhosts_pl_section(self, vhosts_pl_path, section):
         return json.loads(subprocess.check_output([


### PR DESCRIPTION
This is an edge case, but when a vhost has `https_ignore` present the CN (and hence the base filename for the certificate and key) is selected from the `dns_names` set using `pop` before the contents of the `https_ignore` list are removed. This means that the CN used isn't chosen in a deterministic fashion and there is a small risk that it may be in the `https_ignore` list.

This change removes the contents of `https_ignore` before simply returning the sorted contents of the `dns_names` set in cases where the usual CN should be ignored. Behaviour in other cases should be unchanged.

This makes it easier to determine elsewhere what filenames to expect for a given vhost as these are now generated in a slightly more predictable manner.