### PR TITLE
Catch exceptions from call to simp_le

### DIFF
--- a/letsencrypt.py
+++ b/letsencrypt.py
@@ -105,11 +105,15 @@ class CertManagerCallable(object):
             cmd_prefix = []
             actual_cwd = vhost_cwd
 
-        subprocess.check_call(cmd_prefix + [
-            'simp_le', '--email', 'infrastructure@mysociety.org',
-            '--default_root', '/data/letsencrypt/webroot/'] + all_vhosts_args + [
-            '-f', 'key.pem', '-f', 'account_key.json', '-f', 'account_reg.json', '-f', 'fullchain.pem',
-            '--server', ca_url], cwd=actual_cwd)
+        try:
+            subprocess.check_call(cmd_prefix + [
+                'simp_le', '--email', 'infrastructure@mysociety.org',
+                '--default_root', '/data/letsencrypt/webroot/'] + all_vhosts_args + [
+                '-f', 'key.pem', '-f', 'account_key.json', '-f', 'account_reg.json', '-f', 'fullchain.pem',
+                '--server', ca_url], cwd=actual_cwd)
+        except subprocess.CalledProcessError as e:
+            print("Failed to get certificate for {}: command {} exited {}".format(cert_name, e.cmd, e.returncode))
+            return
 
         if self.dry_run:
             print("Rename key.pem to %s.key" % cert_name)


### PR DESCRIPTION
When trying to obtain a certificate `letsencrypt.py` calls out via `subprocess.check_call` to `simp_le`. This commit adds some exception handling so that any errors returned by this call are caught and reported rather than halting execution.

This was fine when running directly as a one-off, but is an issue when calls were being made for certificate renewals (via `renew.py --renew`) as a problem with one certificate resulted in execution halting and no further renewals being processed, so the queue of pending renewals would just grow. By catching the error and printing an error statement, we should get a log of the problem but continue to get all other certificates renewed.