### PR TITLE
acme-sh-helper: Use Cloudflare plugin for WDTK renewals

### DIFF
--- a/acme-sh-helper
+++ b/acme-sh-helper
@@ -39,13 +39,23 @@ export NSUPDATE_KEY="/data/letsencrypt/etc/acme.key"
 echo "==> Attempting to issue cert for $DOMAIN"
 cd /data/letsencrypt/acme.sh
 source ./acme.sh.env
-./acme.sh --issue -d ${DOMAIN} -d "*.${DOMAIN}" \
-	  --domain-alias ${DOMAIN}.acme.mysociety.org \
-	  --dns dns_nsupdate \
-          --keylength 4096 \
-          --server letsencrypt \
-	  --pre-hook "/data/vhost/acme-challenge.mysociety.org/ssl-scripts/acme-pre-hook" \
-	  $STAGING $FORCE
+if [ "$DOMAIN" == "whatdotheyknow.com" ]; then
+    source /data/letsencrypt/etc/cf_token.sh
+    ./acme.sh --issue -d ${DOMAIN} -d "*.${DOMAIN}" \
+              --dns dns_cf \
+              --keylength 4096 \
+              --server letsencrypt \
+              --pre-hook "/data/vhost/acme-challenge.mysociety.org/ssl-scripts/acme-pre-hook" \
+	      $STAGING $FORCE
+else
+    ./acme.sh --issue -d ${DOMAIN} -d "*.${DOMAIN}" \
+	      --domain-alias ${DOMAIN}.acme.mysociety.org \
+	      --dns dns_nsupdate \
+              --keylength 4096 \
+              --server letsencrypt \
+	      --pre-hook "/data/vhost/acme-challenge.mysociety.org/ssl-scripts/acme-pre-hook" \
+	      $STAGING $FORCE
+fi
 
 if [ "$?" -ne "0" ] ; then
    echo "==> There was a problem issuing the certificate for ${DOMAIN}."


### PR DESCRIPTION
We've moved WDTK DNS behind Cloudflare for the time being. This is a bit of a hack but should permit renewing the wildcard certs using their API.

We probably want a flag in config somewhere that will allow us to select a particular provider, etc, but this will do for now.