### PR TITLE
Logging and error management improvements for renew command.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ charset-normalizer==3.2.0
 cryptography==42.0.4
 idna==2.7
 josepy==1.13.0
+loguru==0.7.3
 mock==5.1.0
 pycparser==2.21
 pyOpenSSL==24.0.0


### PR DESCRIPTION
Fixes https://github.com/mysociety/sysadmin/issues/2106.
Fixes https://github.com/mysociety/sysadmin/issues/1145.

Corresponding cron change will be from:
```
/home/letsencrypt/bin/renew --renew >>/var/log/letsencrypt/autorenew.log 2>&1
```
to
```
/home/letsencrypt/bin/renew --renew --log-file /var/log/letsencrypt/autorenew.log
```

Verified by running `./renew.py --log-file ~/autorenew.log --weeks 100` as the `letsencrypt` user on a checkout on the management server with the following patch. Note venv was already updated with new `loguru` dep.
```
diff --git a/acme-sh-helper b/acme-sh-helper
index 9df6008..252b63d 100755
--- a/acme-sh-helper
+++ b/acme-sh-helper
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 CERT_NAME=
 DOMAINS=()
@@ -92,7 +92,6 @@ source ./acme.sh.env
           $DOMAIN_ALIAS \
           --server $SERVER \
           --keylength 4096 \
-          --pre-hook "/data/vhost/acme-challenge.mysociety.org/ssl-scripts/acme-pre-hook" \
           $FORCE
 
 if [ "$?" -ne "0" ] ; then
diff --git a/renew.py b/renew.py
index b0f8f05..a1d7e2d 100755
--- a/renew.py
+++ b/renew.py
@@ -83,20 +83,22 @@ class CertRenewerCallable(object):
 
     def renew(self):
         failed = False
+        wildcard_quota = 2
+        group_quota = 2
+        vhost_quota = 2
         for data in sorted(self.get_cert_data(), key=lambda x: x['expiry']):
-            if data['expiry'] >= self.future:
-                continue
-
             cmc = CertManagerCallable()
             cmc_args = argparse.Namespace
             cmc_args.dry_run = False
-            cmc_args.which_ca = 'prod'
+            cmc_args.which_ca = 'staging'
             cmc_args.vhosts_pl_path = '/data/vhosts.pl'
             cmc_args.all_vhosts = False
             cmc_args.force_issue = True  # Renewals are early so force.
 
             # Deal with wildcard certificates.
-            if data['filename'].startswith('wildcard'):
+            if data['filename'].startswith('wildcard') and wildcard_quota > 0:
+                wildcard_quota -= 1
+                cmc_args.force_issue = True
                 cmc_args.wildcard_cert = data['cn']
                 logger.info('Renewing wildcard %s' % data['cn'])
                 try:
@@ -116,7 +118,8 @@ class CertRenewerCallable(object):
                     continue
 
                 for vhost in vhosts_to_renew:
-                    if vhost.startswith('--group'):
+                    if vhost.startswith('--group') and group_quota > 0:
+                        group_quota -= 1
                         cmc_args.group = vhost.split(' ')[1]
                         logger.info('Renewing group %s' % vhost.split(' ')[1])
                         try:
@@ -124,7 +127,8 @@ class CertRenewerCallable(object):
                         except CertGenerationError:
                             failed = True
                             logger.error('Failed to renew group %s' % vhost.split(' ')[1])
-                    else:
+                    elif vhost_quota > 0:
+                        vhost_quota -= 1
                         cmc_args.group = False
                         cmc_args.vhost = [vhost]
                         logger.info('Renewing vhost %s' % self.vhosts[vhost]['domains'][0])
```